### PR TITLE
Add update endpoints

### DIFF
--- a/src/app/api/sites/route.ts
+++ b/src/app/api/sites/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { obterSites, salvarSites, gerarId } from '../../../../utils/fileManager';
+import { obterSites, salvarSites, gerarId, atualizarSite } from '../../../../utils/fileManager';
 import { Site } from '../../../../utils/verificarSite';
 
 export async function GET() {
@@ -85,4 +85,35 @@ export async function DELETE(request: NextRequest) {
       { status: 500 }
     );
   }
-} 
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { id, ...dados } = body;
+
+    if (!id) {
+      return NextResponse.json(
+        { success: false, error: 'ID é obrigatório' },
+        { status: 400 }
+      );
+    }
+
+    const siteAtualizado = await atualizarSite(id, dados);
+
+    if (!siteAtualizado) {
+      return NextResponse.json(
+        { success: false, error: 'Site não encontrado' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ success: true, data: siteAtualizado });
+  } catch (error: any) {
+    console.error('Erro ao atualizar site:', error);
+    return NextResponse.json(
+      { success: false, error: error.message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/tipos/route.ts
+++ b/src/app/api/tipos/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { obterTipos, salvarTipos, gerarId } from '../../../../utils/fileManager';
+import { obterTipos, salvarTipos, gerarId, atualizarTipo } from '../../../../utils/fileManager';
 import { Tipo } from '../../../../utils/verificarSite';
 
 export async function GET() {
@@ -83,4 +83,35 @@ export async function DELETE(request: NextRequest) {
       { status: 500 }
     );
   }
-} 
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { id, ...dados } = body;
+
+    if (!id) {
+      return NextResponse.json(
+        { success: false, error: 'ID é obrigatório' },
+        { status: 400 }
+      );
+    }
+
+    const tipoAtualizado = await atualizarTipo(id, dados);
+
+    if (!tipoAtualizado) {
+      return NextResponse.json(
+        { success: false, error: 'Tipo não encontrado' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ success: true, data: tipoAtualizado });
+  } catch (error: any) {
+    console.error('Erro ao atualizar tipo:', error);
+    return NextResponse.json(
+      { success: false, error: error.message },
+      { status: 500 }
+    );
+  }
+}

--- a/utils/fileManager.ts
+++ b/utils/fileManager.ts
@@ -151,4 +151,22 @@ export async function salvarMonitoramento(monitoramento: Record<string, SiteStat
 
 export function gerarId(): string {
   return Date.now().toString() + Math.random().toString(36).substr(2, 9);
-} 
+}
+
+export async function atualizarSite(id: string, dados: Partial<Site>): Promise<Site | null> {
+  const sites = await obterSites();
+  const index = sites.findIndex(site => site.id === id);
+  if (index === -1) return null;
+  sites[index] = { ...sites[index], ...dados };
+  await salvarSites(sites);
+  return sites[index];
+}
+
+export async function atualizarTipo(id: string, dados: Partial<Tipo>): Promise<Tipo | null> {
+  const tipos = await obterTipos();
+  const index = tipos.findIndex(tipo => tipo.id === id);
+  if (index === -1) return null;
+  tipos[index] = { ...tipos[index], ...dados };
+  await salvarTipos(tipos);
+  return tipos[index];
+}


### PR DESCRIPTION
## Summary
- allow editing sites and types via new update functions
- expose PUT /api/sites and PUT /api/tipos routes

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_688112fefe148327b15c5aa8d83a79e3